### PR TITLE
Add all options that append support, let each property be optional

### DIFF
--- a/lib/form_data.d.ts
+++ b/lib/form_data.d.ts
@@ -14,7 +14,10 @@ declare class FormData {
 
 declare module FormData {
   export interface Options {
-    filename: string;
+    filename?: string;
+    knownLength?: number;
+    header?: string;
+    contentType?: string;
   }
 
   export interface Headers {


### PR DESCRIPTION
When I use the `contentType` option of `append` method, the ts compiler reports error, since `contentType` is not declared in this typing. So I add all the options that the lib supports to this typing.
